### PR TITLE
Hacky fix for hdf5 exception due to wrong data type (dont merge!)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
 		<dependency>
 			<groupId>net.imglib2</groupId>
 			<artifactId>imglib2</artifactId>
-			<version>3.1.0</version>
+			<version>3.2.1</version>
 		</dependency>
 		<dependency>
 			<groupId>net.imglib2</groupId>
@@ -118,11 +118,6 @@
 		<dependency>
 			<groupId>sc.fiji</groupId>
 			<artifactId>trakem2_tps</artifactId>
-		</dependency>
-		<dependency>
-			<groupId>org.janelia</groupId>
-			<artifactId>render-app</artifactId>
-			<version>0.3.0-SNAPSHOT</version>
 		</dependency>
 	</dependencies>
 

--- a/src/main/java/org/janelia/saalfeldlab/deform/DeformToAligned.java
+++ b/src/main/java/org/janelia/saalfeldlab/deform/DeformToAligned.java
@@ -53,7 +53,7 @@ public class DeformToAligned {
 		public String inFileLabels = null;
 
 		@Parameter( names = { "--label", "-l" }, description = "label dataset" )
-		public List<String> labels = Arrays.asList( new String[]{"/volumes/labels/clefts", "/volumes/labels/neuron_ids"});
+		public List<String> labels = Arrays.asList( new String[]{"/volumes/labels/neuron_ids","/volumes/labels/clefts","/volumes/labels/clefts_corrected"});
 
 		@Parameter(names = { "--outfile", "-o" }, description = "output CREMI-format HDF5 file name")
 		public String outFile;
@@ -180,6 +180,7 @@ public class DeformToAligned {
 			/* labels */
 			for (final String labelsPath : params.labels) {
 
+                System.out.println("transforming: " + labelsPath);
 				final RandomAccessibleInterval<LabelMultisetType> labelsSource = Util.loadLabels(labelsReader, labelsPath, cellDimensions);
 
 				final RandomAccessibleInterval<LongType> longLabelsSource = Converters.convert(labelsSource,
@@ -219,12 +220,17 @@ public class DeformToAligned {
 							params.meshCellSize);
 
 					/* save */
+                    // FIXME This threw the following exception
+                    // Exception in thread "main" ncsa.hdf.hdf5lib.exceptions.HDF5FunctionArgumentException: Invalid arguments to routine:Bad value ["H5Dio.c line 686 in H5D__write(): src dataspace has invalid selection"]
+                    // which I have 'fixed' by now with replacing 'saveUnsignedLong' with 'saveLong'
+                    // maybe different HDF5 versions?
 					System.out.println("writing " + labelsPath);
-					H5Utils.saveUnsignedLong(
+					H5Utils.saveLong(
 							labelsTarget,
 							outFile,
 							labelsPath,
 							cellDimensions);
+					System.out.println("done!");
 				}
 
 				H5Utils.saveAttribute(new double[] { 40.0, 4.0, 4.0 }, writer, labelsPath, "resolution");


### PR DESCRIPTION
When running the 'DeformToAlign' - script, I ran into an hdf5 exception due to a wrong data type.
I have fixed this with a dirty hack (saveLong instead of saveUnsignedLong) for now,
but someone should look into what is actually causing this.